### PR TITLE
automatically install packages and launch RStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SF_ODM
 SF_ODM
-San Francisco Open Data Mapping Projects. 
+San Francisco Open Data Mapping Projects.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Averysaurus/SF_ODM/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Averysaurus/SF_ODM/master?urlpath=rstudio)

--- a/install.R
+++ b/install.R
@@ -1,0 +1,5 @@
+install.packages("Rsocrata")
+install.packages("ggplot2")
+install.packages("dplyr")
+install.packages("tmap")
+install.packages("sf")


### PR DESCRIPTION
Hi @Averysaurus here's a pull request that you can merge that will automatically install the R packages that you need (see the `install.R` file that is added by this), and then also will automatically launch RStudio when you click the binder badge.